### PR TITLE
Fix next_feats dimension mismatch

### DIFF
--- a/node.h
+++ b/node.h
@@ -11,7 +11,7 @@ public:
     int msg_dim;
     float** input_feats;  // (num_heads, feat_dim)
     float** msgs;  // (num_heads, msg_dim)
-    float** next_input_feats;  // (num_heads, feat_dim)
+    float** next_input_feats;  // (num_heads, msg_dim)
 
     node(int n_feats, int n_heads, int message_dim) : feat_dim(n_feats), num_heads(n_heads),
                                                       msg_dim(message_dim){
@@ -25,7 +25,7 @@ public:
       }
       next_input_feats = (float**)calloc(sizeof(float*), num_heads);
       for (int i = 0; i < num_heads; i++) {
-        next_input_feats[i] = (float*)calloc(sizeof(float), feat_dim);
+        next_input_feats[i] = (float*)calloc(sizeof(float), msg_dim);
       }
 
     }
@@ -46,15 +46,16 @@ public:
 //      }
     }
     void flush() {
-      float** tmp = input_feats;
-      input_feats = next_input_feats;
-      next_input_feats = tmp;
+        // FIXME: input_feats and next_input_feats have different dimensions
+//      float** tmp = input_feats;
+//      input_feats = next_input_feats;
+//      next_input_feats = tmp;
       zero_out();
     }
 
     void zero_out() {
       for (int i = 0; i < num_heads; i++) {
-        for (int j = 0; j < feat_dim; j++)
+        for (int j = 0; j < msg_dim; j++)
           next_input_feats[i][j] = 0.f;
       }
     }


### PR DESCRIPTION
As suggested by https://github.com/Kiwisher/Parallel-GAT/blob/5ac3a5548b3bd53e1dc2493b3a0ed11691f0a851/gat.h#L80-L82,

next_input_feats should have dimension (num_heads, msg_dim), rather than (num_heads, feat_dim).